### PR TITLE
Develop

### DIFF
--- a/ore-core/pom.xml
+++ b/ore-core/pom.xml
@@ -29,6 +29,12 @@
 		<dependency>
 			<groupId>org.dllearner</groupId>
 			<artifactId>components-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>google-collections</artifactId>
+					<groupId>com.google.collections</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/ore-ui/pom.xml
+++ b/ore-ui/pom.xml
@@ -178,6 +178,10 @@
 					<artifactId>owlapi-apibinding</artifactId>
 					<groupId>net.sourceforge.owlapi</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>google-collections</artifactId>
+					<groupId>com.google.collections</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
While updating the AKSW packaging I stumbled upon the following error in develop:

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] workspace/ore-core/src/main/java/org/aksw/mole/ore/util/PermutationsOfN.java:[41,31] cannot find symbol
  symbol:   method permutations(java.util.List<T>)
  location: class com.google.common.collect.Collections2
[ERROR] workspace/ore-core/src/main/java/org/aksw/mole/ore/util/PermutationsOfN.java:[44,33] cannot find symbol
  symbol:   method permutations(java.util.List<T>)
  location: class com.google.common.collect.Collections2
```

This is the result of a conflict with guava and the old google-collections library. 
